### PR TITLE
server: Rename streamingRangeLimit to something less confusing

### DIFF
--- a/shared/src/classes/SharedVirtualEntityGroup.cpp
+++ b/shared/src/classes/SharedVirtualEntityGroup.cpp
@@ -6,5 +6,5 @@ extern js::Class baseObjectClass;
 extern js::Class sharedVirtualEntityGroupClass("SharedVirtualEntityGroup", &baseObjectClass, nullptr, [](js::ClassTemplate& tpl)
 {
     tpl.LazyProperty<&alt::IVirtualEntityGroup::GetID>("id");
-    tpl.LazyProperty<&alt::IVirtualEntityGroup::GetStreamingRangeLimit>("streamingRangeLimit");
+    tpl.LazyProperty<&alt::IVirtualEntityGroup::GetStreamingRangeLimit>("maxStreamedEntityCount");
 });

--- a/shared/src/factories/VirtualEntityGroupFactory.cpp
+++ b/shared/src/factories/VirtualEntityGroupFactory.cpp
@@ -2,7 +2,7 @@
 
 // clang-format off
 static js::FactoryHandler virtualEntityGroupFactory(alt::IBaseObject::Type::VIRTUAL_ENTITY_GROUP, [](js::Object& args) -> alt::IBaseObject* {
-    uint32_t streamingRangeLimit;
-    if(!args.Get("streamingRangeLimit", streamingRangeLimit)) return nullptr;
-    return alt::ICore::Instance().CreateVirtualEntityGroup(streamingRangeLimit);
+    uint32_t maxStreamedEntityCount;
+    if(!args.Get("maxStreamedEntityCount", maxStreamedEntityCount)) return nullptr;
+    return alt::ICore::Instance().CreateVirtualEntityGroup(maxStreamedEntityCount);
 });


### PR DESCRIPTION
Same name is used in typings of v1: https://github.com/altmp/altv-types/blob/40d857d528547a4650b75c0688a19e36aedc5561/server/index.d.ts#L638