### PR TITLE
types: boolean for Vehicle.manualEngineControl instead number

### DIFF
--- a/types/server/index.d.ts
+++ b/types/server/index.d.ts
@@ -525,7 +525,7 @@ declare module "@altv/server" {
         petrolTankHealth: number;
         bodyHealth: number;
         bodyAdditionalHealth: number;
-        manualEngineControl: number;
+        manualEngineControl: boolean;
         damageDataBase64: string;
         scriptDataBase64: string;
         gameStateDataBase64: string;


### PR DESCRIPTION
Isn't it better to expect a boolean for manualEngineControl setter instead of a number?

Any positive number returns true, which is the same thing and seems more consistent to me.