### PR TITLE
client: fix Entity & Player synced meta types

### DIFF
--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -648,6 +648,9 @@ declare module "@altv/client" {
 
         static getByID(id: number): Player | null;
         static getByRemoteID(id: number): Player | null;
+
+        readonly syncedMeta: Readonly<altShared.PlayerSyncedMeta>;
+        readonly streamSyncedMeta: Readonly<altShared.PlayerStreamSyncedMeta>;
     }
 
     export interface RmlDocumentCreateOptions {

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -326,7 +326,7 @@ declare module "@altv/client" {
 
         rot: altShared.Vector3;
 
-        readonly syncedMeta: altShared.EntitySyncedMeta;
+        readonly syncedMeta: Readonly<altShared.EntitySyncedMeta>;
         readonly streamSyncedMeta: Readonly<altShared.EntityStreamSyncedMeta>;
 
         static readonly all: ReadonlyArray<Entity>;

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -326,8 +326,8 @@ declare module "@altv/client" {
 
         rot: altShared.Vector3;
 
-        readonly syncedMeta: Readonly<Record<string, unknown>>;
-        readonly streamSyncedMeta: Readonly<Record<string, unknown>>;
+        readonly syncedMeta: altShared.EntitySyncedMeta;
+        readonly streamSyncedMeta: Readonly<altShared.EntityStreamSyncedMeta>;
 
         static readonly all: ReadonlyArray<Entity>;
     }


### PR DESCRIPTION
Client types:
- Fix Entity's synced meta types that didn't use custom interfaces
- Add streamSyncedMeta and syncedMeta to Player