### PR TITLE
use proper event naming convention for player vehicle events

### DIFF
--- a/client/js/events/player.js
+++ b/client/js/events/player.js
@@ -3,5 +3,5 @@ const { Event } = requireBinding("shared/events.js");
 Event.register(alt.Enums.EventType.PLAYER_WEAPON_SHOOT_EVENT, "PlayerWeaponShoot");
 Event.register(alt.Enums.EventType.PLAYER_BULLET_HIT_EVENT, "PlayerBulletHit");
 Event.register(alt.Enums.EventType.PLAYER_WEAPON_CHANGE, "PlayerWeaponChange");
-Event.register(alt.Enums.EventType.PLAYER_START_ENTER_VEHICLE, "PlayerStartEnterVehicle");
-Event.register(alt.Enums.EventType.PLAYER_START_LEAVE_VEHICLE, "PlayerStartLeaveVehicle");
+Event.register(alt.Enums.EventType.PLAYER_START_ENTER_VEHICLE, "PlayerStartVehicleEnter");
+Event.register(alt.Enums.EventType.PLAYER_START_LEAVE_VEHICLE, "PlayerStartVehicleLeave");

--- a/client/src/events/PlayerEvent.cpp
+++ b/client/src/events/PlayerEvent.cpp
@@ -17,7 +17,7 @@ static js::Event playerBulletHitEvent(alt::CEvent::Type::PLAYER_BULLET_HIT_EVENT
     args.Set("pos", e->GetPosition());
 });
 
-static js::Event playerStartEnterVehicle(alt::CEvent::Type::PLAYER_START_ENTER_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
+static js::Event playerStartVehicleEnter(alt::CEvent::Type::PLAYER_START_ENTER_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
     auto e = static_cast<const alt::CPlayerStartEnterVehicleEvent*>(ev);
     args.Set("player", e->GetPlayer());
@@ -25,7 +25,7 @@ static js::Event playerStartEnterVehicle(alt::CEvent::Type::PLAYER_START_ENTER_V
     args.Set("seat", e->GetSeat());
 });
 
-static js::Event playerStartLeaveVehicle(alt::CEvent::Type::PLAYER_START_LEAVE_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
+static js::Event playerStartVehicleLeave(alt::CEvent::Type::PLAYER_START_LEAVE_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
     auto e = static_cast<const alt::CPlayerLeaveVehicleEvent*>(ev);
     args.Set("player", e->GetPlayer());

--- a/client/src/events/PlayerEvent.cpp
+++ b/client/src/events/PlayerEvent.cpp
@@ -27,7 +27,7 @@ static js::Event playerStartVehicleEnter(alt::CEvent::Type::PLAYER_START_ENTER_V
 
 static js::Event playerStartVehicleLeave(alt::CEvent::Type::PLAYER_START_LEAVE_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
-    auto e = static_cast<const alt::CPlayerLeaveVehicleEvent*>(ev);
+    auto e = static_cast<const alt::CPlayerStartLeaveVehicleEvent*>(ev);
     args.Set("player", e->GetPlayer());
     args.Set("vehicle", e->GetTarget());
     args.Set("seat", e->GetSeat());

--- a/server/js/passengers.js
+++ b/server/js/passengers.js
@@ -9,14 +9,14 @@ requireBinding("server/events/player.js");
 
 const passengerMap = new Map();
 
-alt.Events.onPlayerEnteredVehicle(({ player, vehicle, seat }) => {
+alt.Events.onPlayerVehicleEntered(({ player, vehicle, seat }) => {
     const passengers = passengerMap.get(vehicle) ?? new Map();
 
     passengers.set(seat, player);
     passengerMap.set(vehicle, passengers);
 });
 
-alt.Events.onPlayerLeftVehicle(({ vehicle, seat }) => {
+alt.Events.onPlayerVehicleLeft(({ vehicle, seat }) => {
     if (!passengerMap.has(vehicle)) return;
 
     const passengers = passengerMap.get(vehicle);

--- a/shared/js/events/player.js
+++ b/shared/js/events/player.js
@@ -2,8 +2,8 @@ const { Event } = requireBinding("shared/events.js");
 
 Event.register(alt.Enums.EventType.PLAYER_CHANGE_ANIMATION_EVENT, "PlayerAnimationChange");
 Event.register(alt.Enums.EventType.PLAYER_WEAPON_CHANGE, "PlayerWeaponChange");
+Event.register(alt.Enums.EventType.PLAYER_ENTERING_VEHICLE, "PlayerStartVehicleEnter");
 Event.register(alt.Enums.EventType.PLAYER_ENTER_VEHICLE, "PlayerVehicleEntered");
-Event.register(alt.Enums.EventType.PLAYER_ENTERING_VEHICLE, "PlayerVehicleStartEnter");
 Event.register(alt.Enums.EventType.PLAYER_LEAVE_VEHICLE, "PlayerVehicleLeft");
 Event.register(alt.Enums.EventType.PLAYER_CHANGE_VEHICLE_SEAT, "PlayerVehicleSeatChange");
 

--- a/shared/js/events/player.js
+++ b/shared/js/events/player.js
@@ -2,9 +2,9 @@ const { Event } = requireBinding("shared/events.js");
 
 Event.register(alt.Enums.EventType.PLAYER_CHANGE_ANIMATION_EVENT, "PlayerAnimationChange");
 Event.register(alt.Enums.EventType.PLAYER_WEAPON_CHANGE, "PlayerWeaponChange");
-Event.register(alt.Enums.EventType.PLAYER_ENTER_VEHICLE, "PlayerEnteredVehicle");
-Event.register(alt.Enums.EventType.PLAYER_ENTERING_VEHICLE, "PlayerEnteringVehicle");
-Event.register(alt.Enums.EventType.PLAYER_LEAVE_VEHICLE, "PlayerLeftVehicle");
+Event.register(alt.Enums.EventType.PLAYER_ENTER_VEHICLE, "PlayerVehicleEntered");
+Event.register(alt.Enums.EventType.PLAYER_ENTERING_VEHICLE, "PlayerVehicleStartEnter");
+Event.register(alt.Enums.EventType.PLAYER_LEAVE_VEHICLE, "PlayerVehicleLeft");
 Event.register(alt.Enums.EventType.PLAYER_CHANGE_VEHICLE_SEAT, "PlayerVehicleSeatChange");
 
 Event.register(alt.Enums.EventType.PLAYER_START_TALKING, "PlayerStartTalking");

--- a/shared/src/events/PlayerEvent.cpp
+++ b/shared/src/events/PlayerEvent.cpp
@@ -12,7 +12,7 @@ static js::Event playerAnimationChangeEvent(alt::CEvent::Type::PLAYER_CHANGE_ANI
     args.Set("newAnimName", e->GetNewAnimationName());
 });
 
-static js::Event playerEnteredVehicleEvent(alt::CEvent::Type::PLAYER_ENTER_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
+static js::Event playerVehicleEnteredEvent(alt::CEvent::Type::PLAYER_ENTER_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
     auto e = static_cast<const alt::CPlayerEnterVehicleEvent*>(ev);
 
@@ -21,7 +21,7 @@ static js::Event playerEnteredVehicleEvent(alt::CEvent::Type::PLAYER_ENTER_VEHIC
     args.Set("seat", e->GetSeat());
 });
 
-static js::Event playerVehicleEnteringEvent(alt::CEvent::Type::PLAYER_ENTERING_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
+static js::Event playerVehicleStartEnterEvent(alt::CEvent::Type::PLAYER_ENTERING_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
     auto e = static_cast<const alt::CPlayerEnteringVehicleEvent*>(ev);
 

--- a/shared/src/events/PlayerEvent.cpp
+++ b/shared/src/events/PlayerEvent.cpp
@@ -21,7 +21,7 @@ static js::Event playerVehicleEnteredEvent(alt::CEvent::Type::PLAYER_ENTER_VEHIC
     args.Set("seat", e->GetSeat());
 });
 
-static js::Event playerVehicleStartEnterEvent(alt::CEvent::Type::PLAYER_ENTERING_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
+static js::Event playerStartVehicleEnterEvent(alt::CEvent::Type::PLAYER_ENTERING_VEHICLE, [](const alt::CEvent* ev, js::Event::EventArgs& args)
 {
     auto e = static_cast<const alt::CPlayerEnteringVehicleEvent*>(ev);
 

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -1504,17 +1504,18 @@ declare module "@altv/client" {
         export function oncePlayerBulletHit(callback: GenericEventCallback<PlayerBulletHitEventParameters>): altShared.Events.EventHandler;
         export function onPlayerWeaponChange(callback: GenericEventCallback<PlayerWeaponChangeEventParameters>): altShared.Events.EventHandler;
         export function oncePlayerWeaponChange(callback: GenericEventCallback<PlayerWeaponChangeEventParameters>): altShared.Events.EventHandler;
-        export function onPlayerStartEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerStartEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerStartLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerStartLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
+
+        export function onPlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerStartVehicleEnter <T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerStartVehicleLeave<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleLeaveEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerStartVehicleLeave<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleLeaveEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeaveEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeaveEventParameters, T>): altShared.Events.EventHandler;
+
         export function onVoiceConnectionUpdate(callback: GenericEventCallback<VoiceConnectionEventParameters>): altShared.Events.EventHandler;
         export function onceVoiceConnectionUpdate(callback: GenericEventCallback<VoiceConnectionEventParameters>): altShared.Events.EventHandler;
-
         export function onPlayerStartTalking<T extends Player>(callback: GenericPlayerEventCallback<{}, T>): altShared.Events.EventHandler;
         export function oncePlayerStartTalking<T extends Player>(callback: GenericPlayerEventCallback<{}, T>): altShared.Events.EventHandler;
         export function onPlayerStopTalking<T extends Player>(callback: GenericPlayerEventCallback<{}, T>): altShared.Events.EventHandler;
@@ -1588,22 +1589,22 @@ declare module "@altv/client" {
             newWeapon: number;
         }
 
-        interface PlayerStartEnterVehicleEventParameters {
+        interface PlayerStartVehicleEnterEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerStartLeaveVehicleEventParameters {
+        interface PlayerStartVehicleLeaveEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerEnterVehicleEventParameters {
+        interface PlayerVehicleEnterEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerLeaveVehicleEventParameters {
+        interface PlayerVehicleLeaveEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
@@ -1728,17 +1729,17 @@ declare module "@altv/client" {
             newAnimName: number;
         }
 
-        interface PlayerEnteredVehicleEventParameters {
+        interface PlayerVehicleEnteredEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerEnteringVehicleEventParameters {
+        interface PlayerVehicleEnteringEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerLeftVehicleEventParameters {
+        interface PlayerVehicleLeftEventParameters {
             vehicle: Vehicle;
             seat: number;
         }

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -1734,11 +1734,6 @@ declare module "@altv/client" {
             seat: number;
         }
 
-        interface PlayerVehicleEnteringEventParameters {
-            vehicle: Vehicle;
-            seat: number;
-        }
-
         interface PlayerVehicleLeftEventParameters {
             vehicle: Vehicle;
             seat: number;

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -1504,12 +1504,12 @@ declare module "@altv/client" {
         export function oncePlayerBulletHit(callback: GenericEventCallback<PlayerBulletHitEventParameters>): altShared.Events.EventHandler;
         export function onPlayerWeaponChange(callback: GenericEventCallback<PlayerWeaponChangeEventParameters>): altShared.Events.EventHandler;
         export function oncePlayerWeaponChange(callback: GenericEventCallback<PlayerWeaponChangeEventParameters>): altShared.Events.EventHandler;
-        export function onPlayerStartEnterVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerStartEnterVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerStartEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerStartEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerStartLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerStartLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerEnterVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerEnterVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnterVehicleEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerLeaveVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeaveVehicleEventParameters, T>): altShared.Events.EventHandler;
         export function onVoiceConnectionUpdate(callback: GenericEventCallback<VoiceConnectionEventParameters>): altShared.Events.EventHandler;

--- a/types/server/index.d.ts
+++ b/types/server/index.d.ts
@@ -1029,12 +1029,12 @@ declare module "@altv/server" {
         export function oncePlayerSpawn<T extends Player>(callback: GenericPlayerEventCallback<{}, T>): altShared.Events.EventHandler;
         export function onPlayerAnimationChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerAnimationChangeEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerAnimationChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerAnimationChangeEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnteredVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerEnteredVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnteredVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerEnteringVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnteringVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerEnteringVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerEnteringVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerLeftVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeftVehicleEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerLeftVehicle<T extends Player>(callback: GenericPlayerEventCallback<PlayerLeftVehicleEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerVehicleStartEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerVehicleStartEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleSeatChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleSeatChangeEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerVehicleSeatChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleSeatChangeEventParameters, T>): altShared.Events.EventHandler;
 
@@ -1356,17 +1356,17 @@ declare module "@altv/server" {
             newAnimName: number;
         }
 
-        interface PlayerEnteredVehicleEventParameters {
+        interface PlayerVehicleEnteredEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerEnteringVehicleEventParameters {
+        interface PlayerVehicleEnteringEventParameters {
             vehicle: Vehicle;
             seat: number;
         }
 
-        interface PlayerLeftVehicleEventParameters {
+        interface PlayerVehicleLeftEventParameters {
             vehicle: Vehicle;
             seat: number;
         }

--- a/types/server/index.d.ts
+++ b/types/server/index.d.ts
@@ -1031,8 +1031,8 @@ declare module "@altv/server" {
         export function oncePlayerAnimationChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerAnimationChangeEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerVehicleStartEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerVehicleStartEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleSeatChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleSeatChangeEventParameters, T>): altShared.Events.EventHandler;

--- a/types/server/index.d.ts
+++ b/types/server/index.d.ts
@@ -1031,8 +1031,8 @@ declare module "@altv/server" {
         export function oncePlayerAnimationChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerAnimationChangeEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerVehicleEntered<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteredEventParameters, T>): altShared.Events.EventHandler;
-        export function onPlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
-        export function oncePlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleEnteringEventParameters, T>): altShared.Events.EventHandler;
+        export function onPlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
+        export function oncePlayerStartVehicleEnter<T extends Player>(callback: GenericPlayerEventCallback<PlayerStartVehicleEnterEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
         export function oncePlayerVehicleLeft<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleLeftEventParameters, T>): altShared.Events.EventHandler;
         export function onPlayerVehicleSeatChange<T extends Player>(callback: GenericPlayerEventCallback<PlayerVehicleSeatChangeEventParameters, T>): altShared.Events.EventHandler;
@@ -1361,7 +1361,7 @@ declare module "@altv/server" {
             seat: number;
         }
 
-        interface PlayerVehicleEnteringEventParameters {
+        interface PlayerStartVehicleEnterEventParameters {
             vehicle: Vehicle;
             seat: number;
         }


### PR DESCRIPTION
- Uses uniform event naming convention across client & server.
- Updates passenger property events to align with newly typed ones.
- Updates client & server typings to reflect event changes.