### PR TITLE
server: fix socialID type

### DIFF
--- a/types/server/index.d.ts
+++ b/types/server/index.d.ts
@@ -381,7 +381,7 @@ declare module "@altv/server" {
         readonly name: string;
 
         readonly ip: string;
-        readonly socialID: bigint;
+        readonly socialID: number;
         readonly socialClubName: string;
         readonly hwidHash: bigint;
         readonly hwidExHash: bigint;


### PR DESCRIPTION
``typeof player.socialID`` doesn't return ``bigint``, but ``number``.

Typing mistake, or was it normally supposed to be a ``bigint``?