### PR TITLE
fix(typings, client): add streamSyncedMeta for Vehicles

### DIFF
--- a/client/src/modules/AltModule.cpp
+++ b/client/src/modules/AltModule.cpp
@@ -480,6 +480,15 @@ static void GetPoolEntities(js::FunctionContext& ctx)
     ctx.Return(arr);
 }
 
+static void UpdateClipContext(js::FunctionContext& ctx)
+{
+    if (!ctx.CheckArgCount(1)) return;
+
+    std::unordered_map<std::string, std::string> context;
+    if (!ctx.GetArg(0, context)) return;
+
+    alt::ICore::Instance().UpdateClipContext(context);
+}
 
 // clang-format off
 extern js::Class playerClass, localPlayerClass, vehicleClass, pedClass, objectClass,
@@ -548,6 +557,8 @@ static js::Module altModule("@altv/client", "@altv/shared",
     module.StaticFunction("getPoolSize", GetPoolSize);
     module.StaticFunction("getPoolCount", GetPoolCount);
     module.StaticFunction("getPoolEntities", GetPoolEntities);
+
+    module.StaticFunction("updateClipContext", UpdateClipContext);
 
     module.Namespace(eventsNamespace);
     module.Namespace(discordNamespace);

--- a/shared/src/helpers/Convert.h
+++ b/shared/src/helpers/Convert.h
@@ -428,13 +428,15 @@ namespace js
             if(!keysOpt.has_value()) return std::nullopt;
             const std::vector<std::string>& keys = keysOpt.value();
 
-            for(std::string& key : keys)
+            for(const std::string& key : keys)
             {
                 auto maybeVal = obj->Get(context, js::JSValue(key));
                 v8::Local<v8::Value> val;
                 if(!maybeVal.ToLocal(&val)) continue;
+
                 std::optional<typename T::value_type::second_type> value = CppValue<typename T::value_type::second_type>(val);
                 if(!value.has_value()) continue;
+
                 map.insert({ key, value.value() });
             }
             return map;

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -59,6 +59,8 @@ declare module "@altv/client" {
     export function getPoolCount(pool: string): number;
     export function getPoolEntities(pool: string): Array<number>;
 
+    export function updateClipContext(context: Record<string, string>);
+
     export interface AudioCreateOptions {
         source: string;
         volume: number;

--- a/types/client/index.d.ts
+++ b/types/client/index.d.ts
@@ -1073,6 +1073,8 @@ declare module "@altv/client" {
 
         static setFactory(factory: typeof Vehicle): void;
         static getFactory<T extends Vehicle>(): T;
+
+        readonly streamSyncedMeta: Readonly<altShared.VehicleStreamSyncedMeta>;
     }
 
     export interface TextLabelCreateOptions {

--- a/types/client/package.json
+++ b/types/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@altv/client",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "This package contains the type definitions for the alt:V JS module v2 client types",
     "types": "index.d.ts",
     "files": [


### PR DESCRIPTION
The property was missing, so the types always referred to Entity stream synced meta interface rather than VehicleStreamSyncedMeta.