### PR TITLE
fix(shared): `alt.Events.emit` used unsync version of sdk method

### DIFF
--- a/shared/src/namespaces/SharedEventsNamespace.cpp
+++ b/shared/src/namespaces/SharedEventsNamespace.cpp
@@ -42,7 +42,7 @@ static void Emit(js::FunctionContext& ctx)
 
         args.push_back(val);
     }
-    alt::ICore::Instance().TriggerLocalEvent(eventName, args);
+    alt::ICore::Instance().TriggerLocalEventOnMain(eventName, args);
 }
 
 // clang-format off


### PR DESCRIPTION
Since JS is single threaded, it should use synchronous version of `TriggerLocalEvent`, see v1: https://github.com/altmp/altv-js-module/blob/23fa683ad761aa06a15ed8b7fda418d38b6add20/shared/bindings/BindingsMain.cpp#L88