### PR TITLE
fix(shared): fix crashing when empty value is passed to v8::String::Utf8Value

### DIFF
--- a/shared/src/helpers/Convert.h
+++ b/shared/src/helpers/Convert.h
@@ -277,6 +277,9 @@ namespace js
     }
     inline std::string CppValue(v8::Local<v8::String> val)
     {
+        if (val.IsEmpty()) {
+            return "";
+        }
         return *v8::String::Utf8Value(v8::Isolate::GetCurrent(), val);
     }
     inline double CppValue(v8::Local<v8::Number> val)

--- a/shared/src/helpers/Convert.h
+++ b/shared/src/helpers/Convert.h
@@ -277,9 +277,6 @@ namespace js
     }
     inline std::string CppValue(v8::Local<v8::String> val)
     {
-        if (val.IsEmpty()) {
-            return "";
-        }
         return *v8::String::Utf8Value(v8::Isolate::GetCurrent(), val);
     }
     inline double CppValue(v8::Local<v8::Number> val)

--- a/shared/src/helpers/JS.cpp
+++ b/shared/src/helpers/JS.cpp
@@ -67,8 +67,16 @@ js::StackTrace js::StackTrace::GetCurrent(v8::Isolate* isolate, IResource* resou
     for(int i = framesToSkip; i < stackTrace->GetFrameCount(); i++)
     {
         v8::Local<v8::StackFrame> frame = stackTrace->GetFrame(isolate, i);
+
+        auto scriptName = frame->GetScriptName();
+
+        if(scriptName.IsEmpty()) {
+            continue;
+        }
+
         Frame frameData;
-        frameData.file = PrettifyFilePath(resource, CppValue(frame->GetScriptName()));
+
+        frameData.file = PrettifyFilePath(resource, CppValue(scriptName));
         frameData.line = frame->GetLineNumber();
         if(frame->GetFunctionName().IsEmpty()) frameData.function = "[anonymous]";
         else


### PR DESCRIPTION
fixes #204 

We need to check IsEmpty before calling CppValue, because we want to skip that frame if that's the case. It works now (because Utf8Value crashes if we pass empty value to it) and it will work in the future when we update CppValue to throw an error if value is empty (we don't want to re-throw another error while constructing stacktrace, so we check for IsEmpty early).