### PR TITLE
fix(compatibility): Check if the event is custom via old eventname

### DIFF
--- a/shared/js/compatibility/events.js
+++ b/shared/js/compatibility/events.js
@@ -16,9 +16,10 @@ const eventMap = new Map();
  */
 function on(eventName, callback) {
     const eventType = getEventTypeFromName(eventName) ?? alt.Enums.EventType.SERVER_SCRIPT_EVENT;
-    const custom = isCustomEvent(eventType);
+    const custom = isCustomEvent(eventName);
 
     // alt.log(`[compatibility] Registering event handler for ${eventName} (${eventType} - ${custom ? "custom" : "generic"})`);
+    // alt.log(`[compatibility] `, isCustomEvent(eventName), isCustomEvent(eventType));
 
     if (!custom) {
         cppBindings.toggleEvent(eventType, true);
@@ -53,7 +54,7 @@ function onRemote(eventName, callback) {
  */
 function once(eventName, callback) {
     const eventType = getEventTypeFromName(eventName) ?? alt.Enums.EventType.SERVER_SCRIPT_EVENT;
-    const custom = isCustomEvent(eventType);
+    const custom = isCustomEvent(eventName);
 
     // alt.log(`[compatibility] Registering event handler for ${eventName} (${eventType} - ${custom ? "custom" : "generic"})`);
 
@@ -90,7 +91,7 @@ function onceRemote(eventName, callback) {
  */
 function off(eventName, callback) {
     const eventType = getEventTypeFromName(eventName) ?? alt.Enums.EventType.SERVER_SCRIPT_EVENT;
-    const custom = isCustomEvent(eventType);
+    const custom = isCustomEvent(eventName);
 
     if (!custom) {
         cppBindings.toggleEvent(eventType, false);

--- a/shared/js/compatibility/utils/events.js
+++ b/shared/js/compatibility/utils/events.js
@@ -44,6 +44,20 @@ export function getEventArgumentConverter(eventType, custom = false) {
     return map.get(eventType)?.contextToArgsFunc;
 }
 
-export function isCustomEvent(eventType) {
-    return customEventMap.has(eventType);
+/**
+ * If the provided event is an Enum, it's looking for alt.Enums.EventType/CustomEventType. If it's a string, it's looking for the old event name.
+ * @param {alt.Enums.EventType | string} event
+ * @returns boolean
+ */
+export function isCustomEvent(event) {
+    switch (typeof event) {
+        case "string":
+            for (const { oldEventName } of customEventMap.values()) {
+                if (oldEventName === event) return true;
+            }
+
+        case "number":
+        default:
+            return customEventMap.has(event);
+    }
 }

--- a/shared/js/compatibility/utils/events.js
+++ b/shared/js/compatibility/utils/events.js
@@ -56,6 +56,8 @@ export function isCustomEvent(event) {
                 if (oldEventName === event) return true;
             }
 
+            return false;
+            
         case "number":
         default:
             return customEventMap.has(event);


### PR DESCRIPTION
Fixed #214, probably caused by playerDisconnect sharing enum value with resourceError. (resourceError is a alt.Enums.CustomEventType, this caused it to return playerDisconnect as custom event.)

Code:
```js
import * as alt from "alt-server";

alt.on("playerConnect", (player) => {
  player.spawn(0, 0, 74, 0);
  player.model = "mp_m_freemode_01";

  console.log(`Player ${player.name} connected.`);
});

alt.on("playerDisconnect", (player, reason) => {
  console.log(`Player ${player.name} disconnected. Reason: ${reason}`);
});
```

Output:
```
Player szkiddaj connected.
Player szkiddaj disconnected. Reason: timed out
```