### PR TITLE
fix array buffer deserialization

### DIFF
--- a/shared/src/helpers/ValueBuffer.cpp
+++ b/shared/src/helpers/ValueBuffer.cpp
@@ -230,8 +230,8 @@ std::optional<std::pair<uint8_t*, size_t>> js::ValueSerializer::Serialize(v8::Lo
     writer.resource = resource;
     writer.serializer = &serializer;
 
-    writer.serializer->WriteHeader();
     writer.Magic();
+    writer.serializer->WriteHeader();
     bool result = writer.Value(value);
     if(!result) return std::nullopt;
 
@@ -409,8 +409,8 @@ std::optional<v8::Local<v8::Value>> js::ValueDeserializer::Deserialize(uint8_t* 
     reader.resource = resource;
     reader.deserializer = &deserializer;
 
-    if(!reader.deserializer->ReadHeader(resource->GetContext()).FromMaybe(false)) return std::nullopt;
     if(!reader.Magic()) return std::nullopt;
+    if(!reader.deserializer->ReadHeader(resource->GetContext()).FromMaybe(false)) return std::nullopt;
     v8::Local<v8::Value> value;
     bool result = reader.Value(value);
     if(!result) return std::nullopt;


### PR DESCRIPTION
See same bug in v1: https://github.com/altmp/altv-js-module/pull/322


```js
import alt from '@altv/server'

alt.Events.on('test', (...data) => {
  alt.log({ data })
})

setTimeout(() => {
  // Error: Unable to deserialize cloned data due to invalid or unsupported version
  alt.Events.emit('test', new Uint8Array([1, 2, 3, 4, 5]).buffer)
}, 100)
```