### PR TITLE
fix typed array mvalue serialization

### DIFF
--- a/shared/src/helpers/Convert.cpp
+++ b/shared/src/helpers/Convert.cpp
@@ -136,7 +136,6 @@ alt::MValue js::JSToMValue(v8::Local<v8::Value> val, bool allowFunction)
         else if(val->IsTypedArray())
         {
             v8::Local<v8::TypedArray> typedArray = val.As<v8::TypedArray>();
-            if(!typedArray->HasBuffer()) return core.CreateMValueNone();
             v8::Local<v8::ArrayBuffer> v8Buffer = typedArray->Buffer();
             return core.CreateMValueByteArray((uint8_t*)((uintptr_t)v8Buffer->GetBackingStore()->Data() + typedArray->ByteOffset()), typedArray->ByteLength());
         }


### PR DESCRIPTION
For some reason `HasBuffer` doesn't work as it should and according to [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer) buffer is readonly and should always present in TypedArray

```js
alt.Events.on('test', (...data) => {
  alt.log({ data })
})
alt.Events.emit('test', new Uint8Array([1, 2, 3]))
```
before: `{ data: [ undefined ] }`

after:
```
{
  data: [
    ArrayBuffer {
      [Uint8Contents]: <01 02 03>,
      byteLength: 3
    }
  ]
}
```