### PR TITLE
fix(shared): include integer keys in js::Object::GetKeys

### DIFF
--- a/shared/src/helpers/JS.h
+++ b/shared/src/helpers/JS.h
@@ -298,7 +298,7 @@ namespace js
             v8::MaybeLocal<v8::Array> maybePropNames = object->GetPropertyNames(GetContext(),
                                                                                 v8::KeyCollectionMode::kOwnOnly,
                                                                                 (v8::PropertyFilter)(v8::PropertyFilter::ONLY_ENUMERABLE | v8::PropertyFilter::SKIP_SYMBOLS),
-                                                                                v8::IndexFilter::kSkipIndices,
+                                                                                v8::IndexFilter::kIncludeIndices,
                                                                                 v8::KeyConversionMode::kConvertToString);
             v8::Local<v8::Array> propNames;
             if(!maybePropNames.ToLocal(&propNames)) return keys;


### PR DESCRIPTION
fixes object serialization

```js
import alt from '@altv/server'

alt.meta.test = {
  items: {
    1: {},
    normalKey: {}
  }
}

console.log(alt.meta.test)
```

before:
```
{ items: { normalKey: {} } }
```
after:
```
{ items: { '1': {}, normalKey: {} } }
```